### PR TITLE
Update config.py

### DIFF
--- a/src/plugins/nonebot_plugin_status/config.py
+++ b/src/plugins/nonebot_plugin_status/config.py
@@ -15,18 +15,18 @@ from typing import Any, Dict
 
 from pydantic import BaseSettings, root_validator
 
-CPU_TEMPLATE = "CPU: {{ '%02d' % cpu_usage }}%"
+CPU_TEMPLATE = "CPU: {{ cpu_usage }}%"
 PER_CPU_TEMPLATE = (
     "CPU:\n"
     "{%- for core in per_cpu_usage %}\n"
-    "  core{{ loop.index }}: {{ '%02d' % core }}%\n"
+    "  core{{ loop.index }}: {{ core }}%\n"
     "{%- endfor %}"
 )
-MEMORY_TEMPLATE = "Memory: {{ '%02d' % memory_usage }}%"
+MEMORY_TEMPLATE = "Memory: {{ memory_usage }}%"
 DISK_TEMPLATE = (
     "Disk:\n"
     "{%- for name, usage in disk_usage.items() %}\n"
-    "  {{ name }}: {{ '%02d' % usage.percent }}%\n"
+    "  {{ name }}: {{ usage.percent }}%\n"
     "{%- endfor %}"
 )
 UPTIME_TEMPLATE = "Uptime: {{ uptime }}"


### PR DESCRIPTION
改完之后能显示形如0.3%看着舒服多了
（否则CPU0%和内存40%几乎不会变以为卡了）
改完：
```
CPU: 0.3%
Memory: 49.9%
Disk:
  A:\: 35.1%
Uptime: 1 day, 17:27:56
```

改之前：(连续戳戳数据不变以为卡了）
```
CPU: 0%
Memory: 50%
Disk:
  A:\: 35%
Uptime: 1 day, 17:27:56.002321
```