### PR TITLE
Fix: status swap block missing newline

### DIFF
--- a/src/plugins/nonebot_plugin_status/config.py
+++ b/src/plugins/nonebot_plugin_status/config.py
@@ -27,7 +27,7 @@ MEMORY_TEMPLATE = r"Memory: {{ '%02d' % memory_usage.percent }}%"
 """Default memory status template."""
 
 SWAP_TEMPLATE = (
-    "{% if swap_usage.total %}\nSwap: {{ '%02d' % swap_usage.percent }}%\n{% endif %}"
+    r"{% if swap_usage.total %}Swap: {{ '%02d' % swap_usage.percent }}%{% endif +%}"
 )
 """Default swap status template."""
 

--- a/src/plugins/nonebot_plugin_status/config.py
+++ b/src/plugins/nonebot_plugin_status/config.py
@@ -27,7 +27,7 @@ MEMORY_TEMPLATE = r"Memory: {{ '%02d' % memory_usage.percent }}%"
 """Default memory status template."""
 
 SWAP_TEMPLATE = (
-    r"{% if swap_usage.total %}Swap: {{ '%02d' % swap_usage.percent }}%{% endif %}"
+    "{% if swap_usage.total %}Swap: {{ '%02d' % swap_usage.percent }}%\n{% endif %}"
 )
 """Default swap status template."""
 

--- a/src/plugins/nonebot_plugin_status/config.py
+++ b/src/plugins/nonebot_plugin_status/config.py
@@ -27,7 +27,7 @@ MEMORY_TEMPLATE = r"Memory: {{ '%02d' % memory_usage.percent }}%"
 """Default memory status template."""
 
 SWAP_TEMPLATE = (
-    "{% if swap_usage.total %}Swap: {{ '%02d' % swap_usage.percent }}%\n{% endif %}"
+    "{% if swap_usage.total %}\nSwap: {{ '%02d' % swap_usage.percent }}%\n{% endif %}"
 )
 """Default swap status template."""
 


### PR DESCRIPTION
>trim_blocks
>If this is set to True the first newline after a block is removed (block, not variable tag!). Defaults to False.