### PR TITLE
Bug: 修复 swap endif 标签后换行丢失

### DIFF
--- a/src/plugins/nonebot_plugin_status/__init__.py
+++ b/src/plugins/nonebot_plugin_status/__init__.py
@@ -51,9 +51,7 @@ global_config = get_driver().config
 status_config = Config.parse_obj(global_config)
 status_permission = (status_config.server_status_only_superusers or None) and SUPERUSER
 
-_ev = Environment(
-    lstrip_blocks=True, autoescape=False, enable_async=True
-)
+_ev = Environment(lstrip_blocks=True, autoescape=False, enable_async=True)
 _ev.globals["relative_time"] = relative_time
 _ev.filters["relative_time"] = relative_time
 _ev.filters["humanize_date"] = humanize_date

--- a/src/plugins/nonebot_plugin_status/__init__.py
+++ b/src/plugins/nonebot_plugin_status/__init__.py
@@ -51,7 +51,9 @@ global_config = get_driver().config
 status_config = Config.parse_obj(global_config)
 status_permission = (status_config.server_status_only_superusers or None) and SUPERUSER
 
-_ev = Environment(lstrip_blocks=True, autoescape=False, enable_async=True)
+_ev = Environment(
+    trim_blocks=True, lstrip_blocks=True, autoescape=False, enable_async=True
+)
 _ev.globals["relative_time"] = relative_time
 _ev.filters["relative_time"] = relative_time
 _ev.filters["humanize_date"] = humanize_date

--- a/src/plugins/nonebot_plugin_status/__init__.py
+++ b/src/plugins/nonebot_plugin_status/__init__.py
@@ -52,7 +52,7 @@ status_config = Config.parse_obj(global_config)
 status_permission = (status_config.server_status_only_superusers or None) and SUPERUSER
 
 _ev = Environment(
-    trim_blocks=True, lstrip_blocks=True, autoescape=False, enable_async=True
+    lstrip_blocks=True, autoescape=False, enable_async=True
 )
 _ev.globals["relative_time"] = relative_time
 _ev.filters["relative_time"] = relative_time

--- a/src/plugins/nonebot_plugin_status/config.py
+++ b/src/plugins/nonebot_plugin_status/config.py
@@ -25,7 +25,7 @@ MEMORY_TEMPLATE = r"Memory: {{ '%02d' % memory_usage.percent }}%"
 """Default memory status template."""
 
 SWAP_TEMPLATE = (
-    r"{% if swap_usage.total %}Swap: {{ '%02d' % swap_usage.percent }}%{% endif +%}"
+    r"{% if swap_usage.total +%}Swap: {{ '%02d' % swap_usage.percent }}%{% endif %}"
 )
 """Default swap status template."""
 

--- a/src/plugins/nonebot_plugin_status/config.py
+++ b/src/plugins/nonebot_plugin_status/config.py
@@ -31,7 +31,7 @@ SWAP_TEMPLATE = (
 
 DISK_TEMPLATE = (
     "Disk:\n"
-    "{% for name, usage in disk_usage.items() %}\n"
+    "{% for name, usage in disk_usage.items() %}"
     "  {{ name }}: {{ '%02d' % usage.percent }}%\n"
     "{% endfor %}"
 )


### PR DESCRIPTION
Before:

```
CPU: 03%
Memory: 38%
Runtime: 57.25 minutes
Swap: 00%Disk:
  /app/.env.prod: 80%
  /etc/resolv.conf: 80%
  /etc/hostname: 80%
  /etc/hosts: 80%
```

After:

```
CPU: 05%
Memory: 53%
Runtime: 0.10 minutes
Swap: 02%
Disk:
  C:\: 53%
  D:\: 50%
```